### PR TITLE
addOverlay on launch + launcher label variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ By adding this Cordova plugin the Cordova app becomes the the homescreen (also k
 
 To add plugin into existing Cordova / Phonegap application:
 
-    cordova plugin add https://github.com/honza889/cordova-plugin-kiosk.git
+    cordova plugin add https://github.com/honza889/cordova-plugin-kiosk.git --variable KIOSK_LABEL='My Kiosk Laucher Label'
+
+If no `KIOSK_LABEL` value is defined, the default `Cordova Kiosk Mode` is used.
 
 The `AndroidManifest.xml` should be updated immediately. If not, you can force it by removing and re-adding Android platform:
 

--- a/android/KioskActivity.java
+++ b/android/KioskActivity.java
@@ -39,7 +39,9 @@ public class KioskActivity extends CordovaActivity {
         SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(this.getApplicationContext());
         if(Build.VERSION.SDK_INT >= 23) {
             sp.edit().putBoolean(PREF_KIOSK_MODE, false).commit();
-            checkDrawOverlayPermission();
+            if(checkDrawOverlayPermission()){
+                addOverlay();
+            }
         } else {
             sp.edit().putBoolean(PREF_KIOSK_MODE, true).commit();
             addOverlay();
@@ -48,11 +50,15 @@ public class KioskActivity extends CordovaActivity {
     }
     //http://stackoverflow.com/questions/7569937/unable-to-add-window-android-view-viewrootw44da9bc0-permission-denied-for-t
     @TargetApi(Build.VERSION_CODES.M)
-    public void checkDrawOverlayPermission() {
+    public boolean checkDrawOverlayPermission() {
         if (!Settings.canDrawOverlays(this.getApplicationContext())) {
             Intent intent = new Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
                     Uri.parse("package:" + getPackageName()));
             startActivityForResult(intent, REQUEST_CODE);
+            return false;
+        }
+        else{
+            return true;
         }
     }
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android"
-        id="cordova-plugin-kiosk" version="0.2">
+        id="cordova-plugin-kiosk" version="0.2.0">
 
     <name>Cordova Kiosk Mode</name>
     <author>Jan Kalina</author>

--- a/plugin.xml
+++ b/plugin.xml
@@ -28,6 +28,8 @@
     <js-module src="kiosk.js" name="kioskPlugin">
         <clobbers target="window.KioskPlugin" />
     </js-module>
+        
+    <preference name="KIOSK_LABEL" default="Cordova Kiosk Mode" />
 
     <platform name="android">
 
@@ -56,7 +58,7 @@
                         <category android:name="android.intent.category.DEFAULT" />
                     </intent-filter>
                 </activity>
-            <activity android:label="Rilevatore Presenze Modalità Chiosco" android:launchMode="singleInstance" android:keepScreenOn="true" android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|uiMode" android:windowSoftInputMode="adjustResize" android:name="jk.cordova.plugin.kiosk.KioskActivity" android:screenOrientation="sensorLandscape">
+            <activity android:label="$KIOSK_LABEL" android:launchMode="singleInstance" android:keepScreenOn="true" android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|uiMode" android:windowSoftInputMode="adjustResize" android:name="jk.cordova.plugin.kiosk.KioskActivity" android:screenOrientation="sensorLandscape">
                 <intent-filter>
                     <action android:name="android.intent.action.MAIN" />
                     <category android:name="android.intent.category.DEFAULT" />


### PR DESCRIPTION
- Launch `addOverlay` function on every activity starts/restarts and not only the first time
- Using KIOSK_LABEL during plugin installation to customize the launcher activity label